### PR TITLE
Split Betadisk/MB-02+ Sound & LED menu into 4 options

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -95,7 +95,7 @@ uint8_t  Config::kempstonPort = 0x1F;
 uint8_t  Config::throtling = DEFAULT_THROTTLING;
 bool     Config::CursorAsJoy = true;
 bool     Config::trdosFastMode = false;
-bool     Config::trdosSoundLed = false;
+uint8_t  Config::trdosSoundLed = 0; // 0=Off, 1=Led, 2=Sound, 3=Sound+Led
 uint8_t  Config::trdosBios = 2; // Default: 5.05D
 bool     Config::driveWP[4] = { true, true, true, true };
 #if !PICO_RP2040
@@ -103,7 +103,7 @@ uint8_t  Config::esxdos = 0;
 string   Config::esxdos_hdf_image[2] = {"", ""};
 uint8_t  Config::mb02 = 0;
 bool     Config::mb02WP[4] = { true, true, true, true };
-bool     Config::mb02SoundLed = false;
+uint8_t  Config::mb02SoundLed = 0; // 0=Off, 1=Led, 2=Sound, 3=Sound+Led
 bool     Config::zcontroller = false;
 #endif
 
@@ -552,7 +552,12 @@ void Config::load() {
 #endif
         nvs_get_b("CursorAsJoy", CursorAsJoy, sts);
         nvs_get_b("trdosFastMode", trdosFastMode, sts);
-        nvs_get_b("trdosSoundLed", trdosSoundLed, sts);
+        if (!nvs_get_u8("trdosSoundLedMode", trdosSoundLed, sts)) {
+            // Migrate legacy bool key: true -> Sound+Led (3), false -> Off (0)
+            bool old = false;
+            nvs_get_b("trdosSoundLed", old, sts);
+            trdosSoundLed = old ? 3 : 0;
+        }
         nvs_get_u8("trdosBios", trdosBios, sts);
         for (int i = 0; i < 4; i++) {
             char k[12]; snprintf(k, sizeof(k), "drive%d.wp", i);
@@ -569,7 +574,12 @@ void Config::load() {
             char k[12]; snprintf(k, sizeof(k), "mb02d%d.wp", i);
             nvs_get_b(k, mb02WP[i], sts);
         }
-        nvs_get_b("mb02SoundLed", mb02SoundLed, sts);
+        if (!nvs_get_u8("mb02SoundLedMode", mb02SoundLed, sts)) {
+            // Migrate legacy bool key: true -> Sound+Led (3), false -> Off (0)
+            bool old = false;
+            nvs_get_b("mb02SoundLed", old, sts);
+            mb02SoundLed = old ? 3 : 0;
+        }
         nvs_get_b("zcontroller", zcontroller, sts);
 #endif
         nvs_get_str("SNA_Path", FileUtils::SNA_Path, sts);
@@ -775,7 +785,7 @@ void Config::save() {
 #endif
     nvs_set_str(buf,"CursorAsJoy", CursorAsJoy ? "true" : "false");
     nvs_set_str(buf,"trdosFastMode", trdosFastMode ? "true" : "false");
-    nvs_set_str(buf,"trdosSoundLed", trdosSoundLed ? "true" : "false");
+    nvs_set_u8(buf,"trdosSoundLedMode", trdosSoundLed);
     nvs_set_u8(buf,"trdosBios", trdosBios);
     for (int i = 0; i < 4; i++) {
         char k[12]; snprintf(k, sizeof(k), "drive%d.wp", i);
@@ -790,7 +800,7 @@ void Config::save() {
         char k[12]; snprintf(k, sizeof(k), "mb02d%d.wp", i);
         nvs_set_str(buf, k, mb02WP[i] ? "true" : "false");
     }
-    nvs_set_str(buf,"mb02SoundLed", mb02SoundLed ? "true" : "false");
+    nvs_set_u8(buf,"mb02SoundLedMode", mb02SoundLed);
     nvs_set_str(buf,"zcontroller", zcontroller ? "true" : "false");
 #endif
     nvs_set_str(buf,"SNA_Path",FileUtils::SNA_Path.c_str());

--- a/src/Config.h
+++ b/src/Config.h
@@ -200,7 +200,7 @@ public:
     static bool StartMsg;    
 
     static bool trdosFastMode;
-    static bool trdosSoundLed;
+    static uint8_t trdosSoundLed; // 0=Off, 1=Led, 2=Sound, 3=Sound+Led
     static uint8_t trdosBios; // 0=5.03, 1=5.04TM, 2=5.05D
     static bool driveWP[4];   // TR-DOS per-slot write protect (Drive A..D)
 #if !PICO_RP2040
@@ -210,7 +210,7 @@ public:
     static string esxdos_hdf_image[2];
     static uint8_t mb02;     // 0=OFF 1=ON (MB-02+ disk interface, mutually exclusive with TR-DOS/DivMMC)
     static bool mb02WP[4];   // MB-02+ per-slot write protect
-    static bool mb02SoundLed;// MB-02+ disk sound & LED
+    static uint8_t mb02SoundLed;// MB-02+ disk sound & LED: 0=Off, 1=Led, 2=Sound, 3=Sound+Led
     static bool zcontroller; // Z-Controller SD on ports 0x77/0x57 (mutually exclusive with esxDOS/MB-02+)
 #endif
     

--- a/src/ESPectrum.cpp
+++ b/src/ESPectrum.cpp
@@ -1719,9 +1719,9 @@ void ESPectrum::loop() {
         }
 #endif
         {
-            bool fddSndEnabled = Config::trdosSoundLed;
+            bool fddSndEnabled = (Config::trdosSoundLed & 2) != 0;
 #if !PICO_RP2040
-            if (MB02::enabled) fddSndEnabled = Config::mb02SoundLed;
+            if (MB02::enabled) fddSndEnabled = (Config::mb02SoundLed & 2) != 0;
 #endif
             if (fddSndEnabled) FDDGenSound();
         }
@@ -1751,9 +1751,9 @@ void ESPectrum::loop() {
         bool mix_saa = SAA_emu;
         bool mix_midi = (Midi::enabled == 3);
 #endif
-        bool fddSndEnabledMix = Config::trdosSoundLed;
+        bool fddSndEnabledMix = (Config::trdosSoundLed & 2) != 0;
 #if !PICO_RP2040
-        if (MB02::enabled) fddSndEnabledMix = Config::mb02SoundLed;
+        if (MB02::enabled) fddSndEnabledMix = (Config::mb02SoundLed & 2) != 0;
 #endif
         bool mix_fdd = fddSndEnabledMix && (fddSound.click_count > 0 || fddSound.motor_noise);
         for (int i = 0; i < samplesPerFrame; i++)
@@ -1883,7 +1883,7 @@ void ESPectrum::loop() {
 #endif
         ;
 #if !PICO_RP2040
-    if (MB02::enabled && Config::mb02SoundLed) {
+    if (MB02::enabled && (Config::mb02SoundLed & 1)) {
         // MB-02+ I/O skips the WD1793 command-dispatch paths that drive
         // rvmWD1793::led, so mirror the panel LED off the port-0x13 motor state.
         uint8_t mb02_led = ESPectrum::mb02_fdd.led;
@@ -1895,7 +1895,7 @@ void ESPectrum::loop() {
         }
     } else
 #endif
-    if (hasFdd && Config::trdosSoundLed) {
+    if (hasFdd && (Config::trdosSoundLed & 1)) {
         if (ESPectrum::fdd.led) {
             VIDEO::vga.fillRect(312, 3, 4, 4, zxColor(fdd.led == 2 ? 2 : 1, 1));
         } else {

--- a/src/OSDMain.cpp
+++ b/src/OSDMain.cpp
@@ -1804,22 +1804,22 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool ALT, bool CTRL) {
                             else if (dsk_num == 6) {
                                 // Disk Sound & LED
                                 menu_level = 3;
-                                menu_curopt = 1;
+                                menu_curopt = Config::trdosSoundLed + 1;
                                 menu_saverect = true;
                                 while (1) {
                                     string menu = MENU_SOUNDLED[Config::lang];
-                                    menu += MENU_YESNO[Config::lang];
-                                    uint8_t prev = Config::trdosSoundLed;
-                                    if (prev) {
-                                        menu.replace(menu.find("[Y",0),2,"[*");
-                                        menu.replace(menu.find("[N",0),2,"[ ");
-                                    } else {
-                                        menu.replace(menu.find("[Y",0),2,"[ ");
-                                        menu.replace(menu.find("[N",0),2,"[*");
+                                    menu += MENU_SOUNDLED_SEL[Config::lang];
+                                    int mpos = -1;
+                                    int idx = 0;
+                                    while ((mpos = menu.find("[ ]", mpos + 1)) != (int)string::npos) {
+                                        if (idx == Config::trdosSoundLed)
+                                            menu.replace(mpos, 3, "[*]");
+                                        idx++;
                                     }
+                                    uint8_t prev = Config::trdosSoundLed;
                                     uint8_t opt2 = menuRun(menu);
                                     if (opt2) {
-                                        Config::trdosSoundLed = (opt2 == 1);
+                                        Config::trdosSoundLed = opt2 - 1;
                                         if (Config::trdosSoundLed != prev)
                                             Config::save();
                                         menu_curopt = opt2;
@@ -2127,24 +2127,24 @@ void OSD::do_OSD(fabgl::VirtualKey KeytoESP, bool ALT, bool CTRL) {
                                 }
                             }
                             else if (Config::mb02 && mb02_num == 6) {
-                                // Sound & LED toggle.
+                                // Sound & LED selector: Off / LED / Sound / Sound+LED.
                                 menu_level = 3;
-                                menu_curopt = 1;
+                                menu_curopt = Config::mb02SoundLed + 1;
                                 menu_saverect = true;
                                 while (1) {
                                     string menu = MENU_SOUNDLED[Config::lang];
-                                    menu += MENU_YESNO[Config::lang];
-                                    uint8_t prev = Config::mb02SoundLed;
-                                    if (prev) {
-                                        menu.replace(menu.find("[Y",0),2,"[*");
-                                        menu.replace(menu.find("[N",0),2,"[ ");
-                                    } else {
-                                        menu.replace(menu.find("[Y",0),2,"[ ");
-                                        menu.replace(menu.find("[N",0),2,"[*");
+                                    menu += MENU_SOUNDLED_SEL[Config::lang];
+                                    int mpos = -1;
+                                    int idx = 0;
+                                    while ((mpos = menu.find("[ ]", mpos + 1)) != (int)string::npos) {
+                                        if (idx == Config::mb02SoundLed)
+                                            menu.replace(mpos, 3, "[*]");
+                                        idx++;
                                     }
+                                    uint8_t prev = Config::mb02SoundLed;
                                     uint8_t opt2 = menuRun(menu);
                                     if (opt2) {
-                                        Config::mb02SoundLed = (opt2 == 1);
+                                        Config::mb02SoundLed = opt2 - 1;
                                         if (Config::mb02SoundLed != prev)
                                             Config::save();
                                         menu_curopt = opt2;

--- a/src/messages.h
+++ b/src/messages.h
@@ -432,6 +432,17 @@ static const char *MENU_IMG_TITLE[2] = { "esxDOS Image\n", "Imagen esxDOS\n" };
 
 static const char *MENU_FASTMODE[2] = { "Fast Mode\n", "Modo rápido\n" };
 static const char *MENU_SOUNDLED[2] = { "Sound & LED\n", "Sonido y LED\n" };
+#define MENU_SOUNDLED_SEL_EN \
+    "Off\t[ ]\n"\
+    "LED\t[ ]\n"\
+    "Sound\t[ ]\n"\
+    "Sound+LED\t[ ]\n"
+#define MENU_SOUNDLED_SEL_ES \
+    "Off\t[ ]\n"\
+    "LED\t[ ]\n"\
+    "Sonido\t[ ]\n"\
+    "Sonido+LED\t[ ]\n"
+static const char *MENU_SOUNDLED_SEL[2] = { MENU_SOUNDLED_SEL_EN, MENU_SOUNDLED_SEL_ES };
 static const char *MENU_NMI_TITLE[2] = { "NMI\n", "NMI\n" };
 #define MENU_NMI_EN "NMI\n" "Magic Button\n"
 #define MENU_NMI_ES "NMI\n" "Magic Button\n"


### PR DESCRIPTION
Replace the yes/no toggle with a 4-way selector: Off, LED, Sound, Sound+LED. Encoded as a uint8_t bitmask where bit 0 controls the panel LED and bit 1 controls the FDD audio mix. Settings are stored under new NVS keys trdosSoundLedMode / mb02SoundLedMode; legacy bool keys are migrated (true -> Sound+LED, false -> Off).