### PR TITLE
Fix Kempston joystick unresponsive on port 0x1F reads

### DIFF
--- a/src/Ports.cpp
+++ b/src/Ports.cpp
@@ -406,13 +406,11 @@ IRAM_ATTR uint8_t Ports::input(uint16_t address) {
     }
 
     // Kempston Joystick
-    // Standard Kempston decodes A5=0 (so port 0x1F catches 0x00..0x1F).
-    // Non-standard kempstonPort values (0x37, 0x5F) use exact low-byte match.
+    // Standard Kempston decodes A5=0 — always honored so games like Dizzy
+    // that read port 0x1F keep working even when an alternate kempstonPort
+    // (0x37, 0x5F) is selected for boards that also map joystick reads there.
     if (Config::joystick == JOY_KEMPSTON) {
-      bool kempston_hit = (Config::kempstonPort == 0x1F)
-                              ? ((p8 & 0x20) == 0)
-                              : (p8 == Config::kempstonPort);
-      if (kempston_hit)
+      if (((p8 & 0x20) == 0) || (p8 == Config::kempstonPort))
         return ia ? (port[Config::kempstonPort] ^ 0xA0)
                   : port[Config::kempstonPort];
     }


### PR DESCRIPTION
Commit e029c31 narrowed the Kempston decode so that when kempstonPort was set to a non-standard alternate value (0x37 or 0x5F), only exact low-byte matches were accepted. Users upgrading from v1.2.15 still have kempstonPort=0x37 stored in NVS (the previous default), so reads of the canonical port 0x1F fell through to the floating-bus path and the directional pad appeared unresponsive in games like Dizzy VIII.

Restore the historical behavior: always honor the standard A5=0 Kempston decode, and additionally accept exact matches against the configured alternate port so boards that need 0x37/0x5F still work.