### PR TITLE
Harden Config::save against SD failures

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -862,22 +862,41 @@ void Config::save() {
             }
         }
         // Make sure /.config/pico-spec/<ver>/<board>/ exists before writing.
-        FileUtils::mkdirParents(CONFIG_DIR_BOARD);
-        // Atomic write: write to .tmp, then rename over the original
-        static const char* nvs_tmp = STORAGE_NVS ".tmp";
-        static const char* nvs_path = STORAGE_NVS;
-        FIL* handle = fopen2(nvs_tmp, FA_WRITE | FA_CREATE_ALWAYS);
-        if (handle) {
-            UINT bw;
-            FRESULT wr = f_write(handle, buf.c_str(), buf.size(), &bw);
-            fclose2(handle);
-            if (wr == FR_OK && bw == buf.size()) {
-                f_unlink(nvs_path);
-                f_rename(nvs_tmp, nvs_path);
+        // If mkdir fails (broken/full SD), refuse to write — otherwise the
+        // following f_open would silently fail and we'd lose original state.
+        if (!FileUtils::mkdirParents(CONFIG_DIR_BOARD)) {
+            Debug::log("Config::save FAILED — cannot create %s", CONFIG_DIR_BOARD);
+        } else {
+            // Atomic write: write to .tmp, then rename over the original
+            static const char* nvs_tmp = STORAGE_NVS ".tmp";
+            static const char* nvs_path = STORAGE_NVS;
+            FIL* handle = fopen2(nvs_tmp, FA_WRITE | FA_CREATE_ALWAYS);
+            if (handle) {
+                UINT bw;
+                FRESULT wr = f_write(handle, buf.c_str(), buf.size(), &bw);
+                // f_sync flushes FAT before close so we don't commit the
+                // rename on top of a half-written file when the card stalls.
+                FRESULT sy = (wr == FR_OK) ? f_sync(handle) : wr;
+                fclose2(handle);
+                if (wr == FR_OK && sy == FR_OK && bw == buf.size()) {
+                    // Try rename first; on FR_EXIST drop the original then
+                    // retry, narrowing the window where neither file exists.
+                    FRESULT rn = f_rename(nvs_tmp, nvs_path);
+                    if (rn == FR_EXIST) {
+                        f_unlink(nvs_path);
+                        rn = f_rename(nvs_tmp, nvs_path);
+                    }
+                    if (rn != FR_OK) {
+                        Debug::log("Config::save FAILED — rename error (rn=%d)", rn);
+                        // Leave .tmp behind for manual recovery if needed.
+                    }
+                } else {
+                    // Write failed — remove incomplete temp, keep original intact
+                    f_unlink(nvs_tmp);
+                    Debug::log("Config::save FAILED — write error (wr=%d, sy=%d, bw=%u/%u)", wr, sy, bw, buf.size());
+                }
             } else {
-                // Write failed — remove incomplete temp, keep original intact
-                f_unlink(nvs_tmp);
-                Debug::log("Config::save FAILED — write error (wr=%d, bw=%u/%u)", wr, bw, buf.size());
+                Debug::log("Config::save FAILED — cannot open %s", nvs_tmp);
             }
         }
     }

--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -126,23 +126,26 @@ inline void fclose(FIL& f) {
 }
 
 // Create every directory along an absolute path (intermediate components
-// included). Existing directories are tolerated; this matches the behaviour
-// of `mkdir -p` against FatFs.
-void FileUtils::mkdirParents(const char* path) {
-    if (!path || !*path) return;
+// included). Returns true when the full path exists after the call.
+// FR_EXIST is treated as success; any other failure short-circuits and
+// returns false so callers can refuse to write into a non-existent dir.
+bool FileUtils::mkdirParents(const char* path) {
+    if (!path || !*path) return false;
     char buf[128];
     size_t len = strlen(path);
-    if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+    if (len >= sizeof(buf)) return false;
     memcpy(buf, path, len);
     buf[len] = 0;
     for (size_t i = 1; i < len; ++i) {
         if (buf[i] == '/') {
             buf[i] = 0;
-            f_mkdir(buf);
+            FRESULT r = f_mkdir(buf);
+            if (r != FR_OK && r != FR_EXIST) return false;
             buf[i] = '/';
         }
     }
-    f_mkdir(buf);
+    FRESULT r = f_mkdir(buf);
+    return r == FR_OK || r == FR_EXIST;
 }
 
 void FileUtils::initFileSystem() {

--- a/src/FileUtils.h
+++ b/src/FileUtils.h
@@ -86,7 +86,7 @@ public:
     static void initFileSystem();
     static bool mountSDCard();
     static void unmountSDCard();
-    static void mkdirParents(const char* path);
+    static bool mkdirParents(const char* path);
     static bool checkSDCard();
     static bool remountSD();
     // static String         getAllFilesFrom(const String path);


### PR DESCRIPTION
mkdirParents now reports success so Config::save can refuse to write into a path it could not create; otherwise a broken/full SD silently truncates state to an empty config (no disks, no AY/SAA, etc.).

Atomic write now adds f_sync before fclose so a half-flushed FAT does not get committed by the following rename, checks f_rename's return, and only unlinks the original after rename comes back with FR_EXIST — narrowing the window where neither storage.nvs nor storage.nvs.tmp exists.

https://claude.ai/code/session_011gPfEKgYMiaDUpgzjDoiDb