### PR TITLE
Fix RP2040 OOM regression from static pages46 buffer

### DIFF
--- a/src/ESPectrum.cpp
+++ b/src/ESPectrum.cpp
@@ -689,18 +689,20 @@ void ESPectrum::setup() {
     MemESP::ram[2].assign_ram(new unsigned char[MEM_PG_SZ], 2, false);
     MemESP::ram[3].assign_ram(new unsigned char[MEM_PG_SZ], 3, false);
     ram_pages += 3;
+    // pages 4 and 6 — assign_ram falls back to butter/PSRAM/swap when heap
+    // is below MEM_REMAIN (reserved for framebuffer). 5 and 7 are static
+    // SRAM (pages57). On RP2040 the static pages46 buffer doesn't exist.
+    assign_ram(4);
+    assign_ram(6);
 #else
-    // RP2350: pages 0-3 are pre-bound to static `pages0123` SRAM buffer
-    // (MemESP.cpp). Skip assign_ram so we don't overwrite the static buffer.
+    // RP2350: pages 0-3 pre-bound to static `pages0123`, pages 4,6 to
+    // `pages46`, pages 5,7 to `pages57` (MemESP.cpp). Skip assign_ram so we
+    // don't overwrite the static buffers. Pages 5,7 historically not
+    // counted in ram_pages — keep that behaviour.
     ram_pages += 4;
-#endif
-    // pages 4, 5, 6, 7 are now all in static SRAM buffers (pages46/pages57)
-    // for guaranteed POINTER backing — see MemESP.cpp temp[] init.
-    // Pages 4,6 historically counted in ram_pages via assign_ram; keep that
-    // behaviour so MEM_PG_CNT-aware page-bound checks treat them as RAM.
-    // Pages 5,7 historically not counted — leave them untracked.
     ram_pages += 2;
-    Debug::log("setup: ext_ram: pages 4-7 in static SRAM, freeHeap=%u", getFreeHeap());
+#endif
+    Debug::log("setup: ext_ram: pages 0-7 done, freeHeap=%u", getFreeHeap());
     for (size_t i = 8; i < (MEM_PG_CNT + 2); ++i) {
       assign_ram(i);
     }
@@ -710,18 +712,28 @@ void ESPectrum::setup() {
   } else {
     Debug::log("setup: no ext_ram path, freeHeap=%u", getFreeHeap());
 #if PICO_RP2350
-    // RP2350: pages 0-3 are pre-bound to static `pages0123` (MemESP.cpp).
+    // RP2350: pages 0-3 pre-bound to static `pages0123`, pages 4,6 to
+    // `pages46` (MemESP.cpp). Pages 5,7 historically not counted.
     ram_pages += 4;
+    ram_pages += 2;
 #else
     // RP2040: page 0 not supported without virtual memory; pages 1-3 essential.
     MemESP::ram[1].assign_ram(new unsigned char[MEM_PG_SZ], 1, false);
     MemESP::ram[2].assign_ram(new unsigned char[MEM_PG_SZ], 2, false);
     MemESP::ram[3].assign_ram(new unsigned char[MEM_PG_SZ], 3, false);
     ram_pages += 3;
+    // Pages 4,6 only if enough heap remains for framebuffer (MEM_REMAIN).
+    // No ext_ram and 16col mode is disabled on RP2040, so if heap is too
+    // tight these pages stay unbacked (machine effectively 48K).
+    if (getFreeHeap() >= MEM_PG_SZ + MEM_REMAIN) {
+        MemESP::ram[4].assign_ram(new unsigned char[MEM_PG_SZ], 4, false);
+        ++ram_pages;
+    }
+    if (getFreeHeap() >= MEM_PG_SZ + MEM_REMAIN) {
+        MemESP::ram[6].assign_ram(new unsigned char[MEM_PG_SZ], 6, false);
+        ++ram_pages;
+    }
 #endif
-    // Pages 4 and 6 — pre-bound to static `pages46` (MemESP.cpp).
-    // Pages 5,7 historically not counted — leave them untracked.
-    ram_pages += 2;
     Debug::log("setup: no ext_ram: pages done, freeHeap=%u", getFreeHeap());
   }
   // Load romset

--- a/src/MemESP.cpp
+++ b/src/MemESP.cpp
@@ -249,30 +249,24 @@ void mem_desc_t::cleanup() {
 }
 
 mem_desc_t MemESP::rom[64];
-// 8 Z80 RAM pages (the full 128 KB Spectrum 128 RAM) live in static SRAM —
-// predictable POINTER backing on every board, never in butter/PSRAM/swap.
-// Required by the 16col rasterizer which reads pages 4-7 via direct() in
-// the HDMI/VGA ISR.
+// Z80 RAM pages placed in the .ram_128k section, which the RP2350 linker
+// script pins to SRAM banks 0-1 (dedicated 128 KB region). The framebuffer
+// lives in heap (banks 2-7) so HDMI DMA reading the framebuffer travels
+// through different AHB ports than CPU access to Z80 RAM — no bus contention.
+// NOLOAD (no init from flash); pages cleared at runtime in MemESP::reset().
 //
-// Placed in the .ram_pages01234567 section, which the RP2350 linker script
-// pins to SRAM banks 0-1 (a dedicated 128 KB region). The framebuffer ends
-// up in heap which lands in banks 2-7, so HDMI DMA reading the framebuffer
-// travels through different AHB ports than CPU access to Z80 RAM pages —
-// no bus contention.
-//
-// .ram_pages01234567 is NOLOAD (no init from flash) and pages are cleared
-// at runtime in MemESP::reset() / Pentagon boot anyway.
-// alignas(4) keeps each page boundary 32-bit-aligned.
+// On RP2350: all 128 KB of Spectrum 128 RAM (pages 0-7) lives here. The
+// 16col rasterizer (gated `#if !PICO_RP2040` in Video.cpp) reads pages 4-7
+// via direct() in the HDMI/VGA ISR and requires guaranteed POINTER backing.
+// On RP2040: only the video pages 5,7 are static (the rasterizer needs them
+// every line). Pages 0/4/6 are conditionally heap-allocated in setup() —
+// 264 KB total SRAM is too tight to spend 96 KB on static Z80 RAM, and
+// 16col mode is disabled, so pages 4/6 don't need predictable backing.
 #define Z80_RAM_PAGE_ATTR __attribute__((section(".ram_128k"), aligned(4)))
-Z80_RAM_PAGE_ATTR static uint8_t pages46[MEM_PG_SZ * 2];
 Z80_RAM_PAGE_ATTR static uint8_t pages57[MEM_PG_SZ * 2];
 #if !PICO_RP2040
-// On RP2350 also keep pages 0-3 in the same SRAM region (64 KB more),
-// freeing ~64 KB of heap that would otherwise hold them via `new[]`.
-// On RP2040 heap is too tight (~148 KB total) to afford this, and page 0
-// is explicitly placed in PSRAM/swap in setup() to save heap for the
-// framebuffer — leave that path intact.
 Z80_RAM_PAGE_ATTR static uint8_t pages0123[MEM_PG_SZ * 4];
+Z80_RAM_PAGE_ATTR static uint8_t pages46[MEM_PG_SZ * 2];
 #endif
 #undef Z80_RAM_PAGE_ATTR
 static mem_desc_t temp[8] = {
@@ -281,16 +275,20 @@ static mem_desc_t temp[8] = {
     { pages0123 + MEM_PG_SZ * 1, 1 },
     { pages0123 + MEM_PG_SZ * 2, 2 },
     { pages0123 + MEM_PG_SZ * 3, 3 },
+    { pages46   + MEM_PG_SZ * 0, 4 },
+    { pages57   + MEM_PG_SZ * 0, 5 },
+    { pages46   + MEM_PG_SZ * 1, 6 },
+    { pages57   + MEM_PG_SZ * 1, 7 },
 #else
     { 0, 0 },
     { 0, 1 },
     { 0, 2 },
     { 0, 3 },
+    { 0, 4 },
+    { pages57 + MEM_PG_SZ * 0, 5 },
+    { 0, 6 },
+    { pages57 + MEM_PG_SZ * 1, 7 },
 #endif
-    { pages46   + MEM_PG_SZ * 0, 4 },
-    { pages57   + MEM_PG_SZ * 0, 5 },
-    { pages46   + MEM_PG_SZ * 1, 6 },
-    { pages57   + MEM_PG_SZ * 1, 7 },
 };
 mem_desc_t* MemESP::ram = temp;
 bool MemESP::newSRAM = false;


### PR DESCRIPTION
Commit 493ac72 ("Refactor memory management for RP2350") added a static `pages46[32 KB]` buffer to back Z80 RAM pages 4 and 6, replacing the previous conditional heap allocation. The buffer was placed in the `.ram_128k` section (which only the RP2350 linker script defines), but because the section attribute alone does not opt out of memory placement on RP2040, the 32 KB landed in SRAM there too.

On RP2040 that pushes BSS from ~109 KB to ~141 KB, leaving heap below what the 77 KB framebuffer plus pages 1-3 (48 KB) need at boot.

The 16col rasterizer that motivated the static placement is gated `#if !PICO_RP2040` (Video.cpp:50/182/941), so RP2040 never reads pages 4-7 from an ISR and does not need predictable POINTER backing.

Gate `pages46` (and `pages0123`) behind `#if !PICO_RP2040` and restore the original RP2040 setup path: pages 4 and 6 use `assign_ram` (heap if MEM_REMAIN budget allows, else butter/PSRAM/swap) in the ext_ram path, and conditional heap allocation in the no-ext_ram path. `pages57` (video pages, 32 KB) stays static on every platform — that was the pre-regression behaviour and the rasterizer reads them every line.